### PR TITLE
Add multiple carrier handling in kamailio

### DIFF
--- a/conf/kamailio/kamailio-local.cfg
+++ b/conf/kamailio/kamailio-local.cfg
@@ -1,2 +1,3 @@
 #!define RATING_AGENT_URL "http://rating-agent:8000"
 #!define RATING_AGENT_TIMEOUT 1900
+#!define WITH_CANYAN_RATING

--- a/conf/kamailio/kamailio.cfg
+++ b/conf/kamailio/kamailio.cfg
@@ -320,10 +320,10 @@ modparam("sanity", "autodrop", 0)
 # ----- tm params -----
 # auto-discard branches from previous serial forking leg
 modparam("tm", "failure_reply_mode", 3)
-# default retransmission timeout: 30sec
-modparam("tm", "fr_timer", 30000)
-# default invite retransmission timeout after 1xx: 120sec
-modparam("tm", "fr_inv_timer", 120000)
+# default retransmission timeout: 5sec
+modparam("tm", "fr_timer", 5000)
+# default invite retransmission timeout after 1xx: 10sec
+modparam("tm", "fr_inv_timer", 10000)
 
 # ----- rr params -----
 # set next param to 1 to add value to ;lr param (helps with some UAs)
@@ -463,9 +463,12 @@ modparam("debugger", "cfgtrace", 1)
 modparam("debugger", "log_level_name", "exec")
 #!endif
 
-####### Routing Logic ########
-include_file "rating.cfg"
 
+#!ifdef WITH_CANYAN_RATING
+include_file "rating.cfg"
+#!endif
+
+####### Routing Logic ########
 
 /* Main SIP request routing logic
  * - processing of any incoming SIP request starts with this route
@@ -520,12 +523,14 @@ request_route {
         dlg_manage();
     }
 
+#!ifdef WITH_CANYAN_RATING
     # rating authorization
     if (is_method("INVITE") && !has_totag()) {
       $dlg_var(account_tag) = $fU;
 
       route(RATING_AUTHORIZATION);
     }
+#!endif
 
     # dispatch requests to foreign domains
     route(SIPOUT);
@@ -1016,6 +1021,20 @@ failure_route[MANAGE_FAILURE] {
         $du = $null;
         route(TOVOICEMAIL);
         exit;
+    }
+#!endif
+
+#!ifdef WITH_CANYAN_RATING
+    # Manage carrier failure
+    # next destination - only for 500 or local timeout
+    if (t_check_status("500") or (t_branch_timeout() and !t_branch_replied())) {
+        if (defined $dlg_var(du_secondary) && !strempty($dlg_var(du_secondary))) {
+            # relay the packet to the secondary carrier
+            $du = $dlg_var(du_secondary);
+            $dlg_var(du_secondary) = "";
+            route(RELAY);
+            exit;
+        }
     }
 #!endif
 }

--- a/conf/kamailio/rating.cfg
+++ b/conf/kamailio/rating.cfg
@@ -90,14 +90,23 @@ route[RATING_AUTHORIZATION_RESPONSE] {
         jansson_get("carriers", $http_rb, "$dlg_var(carriers)");
         jansson_set("array", "carriers", $dlg_var(carriers), "$var(carriers)");
         jansson_array_size("carriers", $var(carriers), "$var(carriers_size)");
+
+        # there is no carriers in the response
         if ($var(carriers_size) <= 0) {
             xlog("L_ERR", "ERROR: RATING_AUTHORIZATION_RESPONSE var carriers: $var(carriers) - empty\n");
             send_reply(600, "No carrier found");
             exit;
         }
-        jansson_get("carriers[0]", $var(carriers), "$var(carrier)");
-        $var(carrier) = $(var(carrier){s.replace,UDP,sip});
-        $du = $var(carrier);
+
+        jansson_get("carriers[0]", $var(carriers), "$dlg_var(du_primary)");
+        $dlg_var(du_primary) = $(dlg_var(du_primary){s.replace,UDP,sip});
+
+        # we've got more than one carrier, we can store the failover in a dlg_var
+        if ($var(carriers_size) >= 2) {
+            jansson_get("carriers[1]", $var(carriers), "$dlg_var(du_secondary)");
+            $dlg_var(du_secondary) = $(dlg_var(du_secondary){s.replace,UDP,sip});
+        }
+        $du = $dlg_var(du_primary);
 
         route(SIPOUT);
     }

--- a/docker-compose.carrier.yaml
+++ b/docker-compose.carrier.yaml
@@ -7,3 +7,10 @@ services:
   carrier:
     image: 'canyan/carrier:master'
     entrypoint: 'sipp -sf /scenarios/uas.xml'
+
+  #
+  # dead carrier
+  #
+  dead-carrier:
+    image: 'busybox:latest'
+    command: sh -c "while true; do sleep 60; done"

--- a/tests/scenarios/test_kamailio_carrier_failover.xml
+++ b/tests/scenarios/test_kamailio_carrier_failover.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="iso-8859-2" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Basic Sipstone UAC">
+
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:1000@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:%(to_user)s@%(to_domain)s:%(to_port)s>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:1000@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true"></recv>
+  <recv response="180" rrs="true" optional="true"></recv>
+  <recv response="200" rtd="true"></recv>
+
+  <send>
+  <![CDATA[
+
+    ACK [next_url] SIP/2.0
+    [last_Via:]
+    [last_From:]
+    [last_To:]
+    [routes]
+    [last_Call-ID:]
+    CSeq: [cseq] ACK
+    Contact: <sip:1000@[local_ip]:[local_port];transport=[transport]>
+    Max-Forwards: 70
+    Subject: Test
+    Content-Length: 0
+
+  ]]>
+  </send>
+
+  <pause milliseconds="%(call_duration)s" />
+
+  <send retrans="500">
+    <![CDATA[
+
+    BYE [next_url] SIP/2.0
+    Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+    [routes]
+    [last_From:]
+    [last_To:]
+    [last_Call-ID:]
+    CSeq: [cseq] BYE
+    Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+    Max-Forwards: 30
+    Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- The 'crlf' option inserts a blank line in the statistics report. -->
+  <recv response="200" crlf="true"></recv>
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/tests/scenarios/test_kamailio_carrier_failover.yaml
+++ b/tests/scenarios/test_kamailio_carrier_failover.yaml
@@ -1,0 +1,97 @@
+setup:
+  - type: api
+    uri: /graphql
+    method: POST
+    payload:
+      query: |
+        mutation {
+          upsertAccount(
+            name: "Fabio",
+            account_tag: "1000",
+            type: PREPAID,
+            balance: 1000000,
+            active: true,
+            max_concurrent_transactions: 100
+          ) {
+            id
+          }
+          upsertCarrier(
+            carrier_tag: "dead-carrier",
+            active: true,
+            protocol: UDP,
+            host: "dead-carrier",
+            port: 5061
+          ) {
+            id
+          }
+          upsertPricelist(
+            pricelist_tag: "pricelist",
+            currency:EUR
+          ) {
+            id
+          }
+          upsertPricelistRate(
+            carrier_tag: "dead-carrier",
+            pricelist_tag: "pricelist",
+            prefix: "sip:39",
+            active: true,
+            description: "pricelist rate",
+            rate: 1,
+            rate_increment: 1,
+            connect_fee: 0,
+            interval_start: 0
+          ) {
+            id
+          }
+        }
+
+  - type: api
+    uri: /graphql
+    method: POST
+    payload:
+      query: |
+        mutation {
+          upsertCarrier(
+            carrier_tag: "carrier",
+            active: true,
+            protocol: UDP,
+            host: "carrier",
+            port: 5060
+          ) {
+            id
+          }
+          upsertPricelist(
+            pricelist_tag: "pricelist",
+            currency:EUR
+          ) {
+            id
+          }
+          upsertPricelistRate(
+            carrier_tag: "carrier",
+            pricelist_tag: "pricelist",
+            prefix: "sip:39",
+            active: true,
+            description: "pricelist rate",
+            rate: 2,
+            rate_increment: 1,
+            connect_fee: 0,
+            interval_start: 0
+          ) {
+            id
+          }
+        }
+        
+workers:
+  - scenario: "test_kamailio_authorized.xml"
+    number: 1
+    repeat: 2
+    timeout: 600
+    call_rate: 1
+    call_rate_period: 1000
+    call_limit: 1
+    call_number: 1
+    values:
+      call_duration: 1000
+      to_user: "39040123456"
+      to_domain: "anotherdomain.com"
+      to_port: "5060"

--- a/tests/test_kamailio.py
+++ b/tests/test_kamailio.py
@@ -48,3 +48,10 @@ def test_kamailio_unauthorized_unreachable():
     scenario_file = os.path.join(base_dir, 'scenarios', 'test_kamailio_unauthorized_unreachable.yaml')
     result = CliRunner().invoke(canyantester, ['-a', API_URL, '-t', TARGET, scenario_file])
     assert result.exit_code == 0
+
+
+def test_kamailio_carrier_failover():
+    base_dir = os.path.dirname(__file__)
+    scenario_file = os.path.join(base_dir, 'scenarios', 'test_kamailio_carrier_failover.yaml')
+    result = CliRunner().invoke(canyantester, ['-a', API_URL, '-t', TARGET, scenario_file])
+    assert result.exit_code == 0


### PR DESCRIPTION
Now the auth response in case of multiple carriers stores the secondary in a dlg_var and uses it in case of failure.

The failure route has been edited and moved in the rating.cfg. Also, some timers have been altered to fasten up the test execution.

@tranchitella can we fasten the failover tests up more in your opinion?